### PR TITLE
Working on tag helper

### DIFF
--- a/AspNetCoreWeb/TagHelpers/JqueryDataTablesTagHelper.cs
+++ b/AspNetCoreWeb/TagHelpers/JqueryDataTablesTagHelper.cs
@@ -23,6 +23,12 @@ namespace JqueryDataTables.ServerSide.AspNetCoreWeb.TagHelpers
         [HtmlAttributeName("search-input-class")]
         public string SearchInputClass { get; set; }
 
+		[HtmlAttributeName("search-input-style")]
+		public string SearchInputStyle { get; set; }
+
+		[HtmlAttributeName("search-input-placeholder")]
+		public string SearchInputPlaceholder { get; set; }
+
         public override void Process(TagHelperContext context,TagHelperOutput output)
         {
             output.TagName = "table";
@@ -50,7 +56,7 @@ namespace JqueryDataTables.ServerSide.AspNetCoreWeb.TagHelpers
                 headerRow.AppendLine($"<th>{column}</th>");
 
                 if (!EnableSearching) continue;
-                searchRow.AppendLine($@"<th class=""{SearchRowThClass}""><span class=""sr-only"">{column}</span><input type=""search"" class=""{SearchInputClass}"" placeholder=""Search {column}"" aria-label=""{column}"" /></th>");
+                searchRow.AppendLine($@"<th class=""{SearchRowThClass}""><span class=""sr-only"">{column}</span><input type=""search"" style=""{SearchInputStyle}"" class=""{SearchInputClass}"" placeholder=""{SearchInputPlaceholder.Replace("{{name}}", column)}"" aria-label=""{column}"" /></th>");
             }
 
             headerRow.AppendLine("</tr>");

--- a/AspNetCoreWeb/TagHelpers/JqueryDataTablesTagHelper.cs
+++ b/AspNetCoreWeb/TagHelpers/JqueryDataTablesTagHelper.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.AspNetCore.Razor.TagHelpers;
+﻿using JqueryDataTables.ServerSide.AspNetCoreWeb.Attributes;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 using System.ComponentModel;
+using System.Linq;
 using System.Text;
 
 namespace JqueryDataTables.ServerSide.AspNetCoreWeb.TagHelpers
@@ -56,7 +58,12 @@ namespace JqueryDataTables.ServerSide.AspNetCoreWeb.TagHelpers
                 headerRow.AppendLine($"<th>{column}</th>");
 
                 if (!EnableSearching) continue;
-                searchRow.AppendLine($@"<th class=""{SearchRowThClass}""><span class=""sr-only"">{column}</span><input type=""search"" style=""{SearchInputStyle}"" class=""{SearchInputClass}"" placeholder=""{SearchInputPlaceholder.Replace("{{name}}", column)}"" aria-label=""{column}"" /></th>");
+                searchRow.AppendLine($@"<th class=""{SearchRowThClass}""><span class=""sr-only"">{column}</span>");
+				if (prop.Attributes.OfType<SearchableAttribute>().Any())
+				{ 
+					searchRow.AppendLine($@"<input type=""search"" style=""{SearchInputStyle}"" class=""{SearchInputClass}"" placeholder=""{SearchInputPlaceholder.Replace("{{name}}", column)}"" aria-label=""{column}"" />");
+				}
+				searchRow.AppendLine($@"</th>");
             }
 
             headerRow.AppendLine("</tr>");


### PR DESCRIPTION
Hi.

- If property has not Searchable attribute, we dont need to show search input on datatable column.

- Sometimes we may want to change the style of the input.For example `search-input-style="width:100%;"`
- It may also be necessary to change the placeholder. `search-input-placeholder="Arama Yap {{name}}"` **{{name}}** represent column name.
 